### PR TITLE
Modifications to serialize TriggeredSend

### DIFF
--- a/lib/exact_target_rest/authorization.rb
+++ b/lib/exact_target_rest/authorization.rb
@@ -5,6 +5,7 @@ module ExactTargetRest
   # App Center (https://appcenter-auth.exacttargetapps.com).
   class Authorization
     attr_reader :access_token
+    attr_reader :expires_in
 
     # New authorization (it does not trigger REST yet).
     #
@@ -35,8 +36,8 @@ module ExactTargetRest
       end
       if resp.success?
         @access_token = resp.body['accessToken']
-        @expires_in = Time.now + resp.body['expiresIn']
-        { access_token: @access_token, expires_in: @expires_in }
+        @expires_in = resp.body['expiresIn']
+        self
       else
         fail NotAuthorizedError
       end
@@ -44,7 +45,7 @@ module ExactTargetRest
 
     # Already authorized and NOT expired?
     def authorized?
-      @access_token && @expires_in > Time.now
+      @access_token && (Time.now + @expires_in) > Time.now
     end
 
     protected

--- a/lib/exact_target_rest/authorization.rb
+++ b/lib/exact_target_rest/authorization.rb
@@ -22,7 +22,6 @@ module ExactTargetRest
     #
     # @yield [access_token] Block to be executed
     # @yieldparam access_token [String] Access token used to authorize a request
-    # @yieldparam expires_in [String] Time to token's expire
     def with_authorization
       authorize! unless authorized?
       yield @access_token
@@ -51,7 +50,7 @@ module ExactTargetRest
     protected
 
     def endpoint
-      @endpoint ||= Faraday.new(url: AUTH_URL) do |f|
+      Faraday.new(url: AUTH_URL) do |f|
         f.request :json
         f.response :json, content_type: /\bjson$/
         f.adapter FARADAY_ADAPTER

--- a/lib/exact_target_rest/triggered_send.rb
+++ b/lib/exact_target_rest/triggered_send.rb
@@ -58,6 +58,8 @@ module ExactTargetRest
 
     # TriggeredSend with loaded attributes.
     def deliver
+      tries ||= 1
+
       @authorization.with_authorization do |access_token|
         resp = endpoint.post do |p|
           p.url(format(TRIGGERED_SEND_PATH, URI.encode(@external_key)))
@@ -82,6 +84,10 @@ module ExactTargetRest
         raise NotAuthorizedError if resp.status == 401
         resp
       end
+    rescue NotAuthorizedError
+      tries -= 1
+      retry if tries >= 0
+      raise NotAuthorizedError
     end
 
     protected

--- a/lib/exact_target_rest/triggered_send.rb
+++ b/lib/exact_target_rest/triggered_send.rb
@@ -11,7 +11,7 @@ module ExactTargetRest
       @snake_to_camel = snake_to_camel
     end
 
-    # TriggeredSend for just one subscriber. This method exists to keep compatibility.
+    # TriggeredSend for just one subscriber.
     # @param to_address [String] Email to send.
     # @param subscriber_key [String] SubscriberKey (it uses Email if not set).
     # @param data_extension_attributes [{Symbol => Object}] List of attributes (in snake_case)

--- a/lib/exact_target_rest/version.rb
+++ b/lib/exact_target_rest/version.rb
@@ -1,3 +1,3 @@
 module ExactTargetRest
-  VERSION = '0.2.2'
+  VERSION = '0.2.4'
 end

--- a/spec/lib/exact_target_rest/authorization_spec.rb
+++ b/spec/lib/exact_target_rest/authorization_spec.rb
@@ -45,12 +45,20 @@ describe Authorization do
     end
   end
 
+  describe '#to_yaml' do
+    it "serializes and deserializes Authorization" do
+      auth = subject.new(client_id, client_secret).authorize!
+
+      expect(YAML::load(auth.to_yaml)).to be_instance_of(ExactTargetRest::Authorization)
+    end
+  end
+
   private
 
   def stub_requests
-    stub_request(:post, "https://auth.exacttargetapis.com/v1/requestToken").
+    stub_request(:post, ExactTargetRest::AUTH_URL).
       with(
-        :body => "{\"clientId\":\"12345\",\"clientSecret\":\"Y9axRxR9bcvSW2cc0IwoWeq7\"}",
+        :body => "{\"clientId\":\"#{client_id}\",\"clientSecret\":\"#{client_secret}\"}",
         :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
         ).
       to_return(
@@ -61,7 +69,7 @@ describe Authorization do
 
     stub_request(:any, ExactTargetRest::AUTH_URL).
       with(
-        :body => "{\"clientId\":\"invalid\",\"clientSecret\":\"Y9axRxR9bcvSW2cc0IwoWeq7\"}",
+        :body => "{\"clientId\":\"invalid\",\"clientSecret\":\"#{client_secret}\"}",
         :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
         ).
       to_return(

--- a/spec/lib/exact_target_rest/authorization_spec.rb
+++ b/spec/lib/exact_target_rest/authorization_spec.rb
@@ -34,8 +34,8 @@ describe Authorization do
     it "returns a valid authorization" do
       auth = subject.new(client_id, client_secret).authorize!
 
-      expect(auth[:access_token]).to eq access_token
-      expect(auth[:expires_in]).not_to be_nil
+      expect(auth.access_token).to eq access_token
+      expect(auth.expires_in).not_to be_nil
     end
 
     it "returns Unauthorized" do

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -7,8 +7,8 @@ describe TriggeredSend do
   let(:expires_in) { 3600 }
 
   subject do
-    authorization = instance_double("ExactTargetRest::Authorization")
-    allow(authorization).to receive(:with_authorization).and_yield(access_token)
+    authorization = ExactTargetRest::Authorization.new("client_id","client_sec")
+    allow(authorization).to receive(:access_token).and_return(access_token)
     described_class.new(authorization,external_key)
   end
 

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -7,8 +7,8 @@ describe TriggeredSend do
   let(:expires_in) { 3600 }
 
   subject do
-    authorization = ExactTargetRest::Authorization.new("client_id","client_sec")
-    allow(authorization).to receive(:access_token).and_return(access_token)
+    authorization = instance_double("ExactTargetRest::Authorization")
+    allow(authorization).to receive(:with_authorization).and_yield(access_token)
     described_class.new(authorization,external_key)
   end
 

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -56,6 +56,20 @@ describe TriggeredSend do
 
   end
 
+  describe '#to_yaml' do
+    it "serializes and deserializes TriggeredSend" do
+      authorization = ExactTargetRest::Authorization.new("client_id", "client_secret").authorize!
+
+      ts = ExactTargetRest::TriggeredSend.new(authorization, "external_key").
+        with_options(
+          email_address: "jake@oo.com",
+          subscriber_attributes: { "City" => "São Paulo", "Profile ID" => "42" }
+          )
+
+      expect(YAML::load(ts.to_yaml)).to be_instance_of(ExactTargetRest::TriggeredSend)
+    end
+  end
+
   private
 
   def stub_requests


### PR DESCRIPTION
Did some modifications to serialize `TriggeredSend` on async workers.

When using and `Authorization.authorized!` as parameter of `TriggeredSend`, it returned an serialization error because of `@endpoint`. So it was removed, because the call cache can be made from client side.

Also I needed the `expires_in` value after `authorize!` and added it as attribute.
