### PR TITLE
Allow customization of Faraday connection and deliver response

### DIFF
--- a/exact_target_rest.gemspec
+++ b/exact_target_rest.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
 
+  spec.add_development_dependency 'faraday', '~> 0.9.0'
+  spec.add_development_dependency 'faraday_middleware', '~> 0.9.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'

--- a/lib/exact_target_rest/authorization.rb
+++ b/lib/exact_target_rest/authorization.rb
@@ -16,6 +16,12 @@ module ExactTargetRest
       @client_id, @client_secret = client_id, client_secret
     end
 
+    # Customize the Faraday connection by passing in a block
+    #
+    def setup_connection(&block)
+      @endpoint = endpoint(&block)
+    end
+
     # Guarantee the block to run authorized.
     #
     # If not yet authorized, it runs authorization.
@@ -51,12 +57,16 @@ module ExactTargetRest
 
     protected
 
-    def endpoint
-      Faraday.new(url: AUTH_URL) do |f|
-        f.request :json
-        f.response :json, content_type: /\bjson$/
-        f.adapter FARADAY_ADAPTER
-      end
+    def endpoint(&block)
+      @endpoint || Faraday.new(url: AUTH_URL) do |f|
+                     f.request :json
+                     f.response :json, content_type: /\bjson$/
+                     if block_given?
+                       block.call(f)
+                     else
+                       f.adapter FARADAY_ADAPTER
+                     end
+                   end
     end
   end
 end

--- a/lib/exact_target_rest/version.rb
+++ b/lib/exact_target_rest/version.rb
@@ -1,3 +1,3 @@
 module ExactTargetRest
-  VERSION = '0.2.6'
+  VERSION = '0.3.0'
 end

--- a/spec/lib/exact_target_rest/authorization_spec.rb
+++ b/spec/lib/exact_target_rest/authorization_spec.rb
@@ -30,6 +30,14 @@ describe Authorization do
     end
   end
 
+  describe '#setup_connection' do
+    it 'takes a block to customize the faraday connection' do
+      block = Proc.new {|conn| puts "conn" }
+      expect(block).to receive(:call)
+      subject.new(client_id, client_secret).setup_connection(&block)
+    end
+  end
+
   describe '#authorize!' do
     it "returns a valid authorization" do
       auth = subject.new(client_id, client_secret).authorize!

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -16,6 +16,14 @@ describe TriggeredSend do
     stub_requests
   end
 
+  describe '#setup_connection' do
+    it 'takes a block to customize the faraday connection' do
+      block = Proc.new {|conn| puts "conn" }
+      expect(block).to receive(:call)
+      subject.setup_connection(&block)
+    end
+  end
+
   describe '#send_one' do
     it "sends a simple TriggeredSend" do
       response = subject.send_one(email_address: "jake@oo.com")
@@ -51,6 +59,16 @@ describe TriggeredSend do
         email_address: "jake@oo.com",
         subscriber_attributes: { "City" => "São Paulo", "Profile ID" => "42" }
         ).deliver
+      expect(response.body["requestId"]).to eq "uncommon-key-response-id"
+    end
+
+    it "accepts a block to handle responses" do
+      block = Proc.new { |resp| puts "hello" }
+      expect(block).to receive(:call)
+      response = subject.with_options(
+        email_address: "jake@oo.com",
+        subscriber_attributes: { "City" => "São Paulo", "Profile ID" => "42" }
+        ).deliver(&block)
       expect(response.body["requestId"]).to eq "uncommon-key-response-id"
     end
 


### PR DESCRIPTION
Thanks for the gem! I added some customizations to the gem that I hope you guys consider pulling in:

##### What was added?

* Add support for #setup_connection to customize the Faraday connection.
* Also add support for customizing the deliver response by passing in a
block.
* Restrict faraday version to 0.9.x in development or webmock fails as
the format has changed slightly
* Update VERSION to 0.3.0 to reflect the API changes

##### Why did this get added?

* We wanted to add additional middleware to the Faraday connection (for example, [faraday-detailed_logger](https://github.com/envylabs/faraday-detailed_logger)) to debug issues.
* We want to use a different Faraday connection in certain environments (use `Net:HTTP` in non-JRuby environments, and something else in those ENVs)
* Ability to log delivery issues not related to only on `HTTP 401 Unauthorized` errors, but for JSON serialization issues and things like that.