### PR TITLE
Api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Simple wrapper around ExactTarget REST API.
 
 It deals with authorization and with coding conventions (CamelCase vs snake_case).
 
+It only supports packages with enhanced functionality (v2), legacy packages are unsupported (v1).
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -29,9 +31,10 @@ Be sure you have a "Client ID" and a "Client Secret". You can create one in [Exa
 Before anything else, create an **Authorization**:
 
 ```ruby
+auth_url = 'https://acyy6lj5zj3n7gsltjmgv12k0x80.auth.marketingcloudapis.com'
 client_id = '123456'
 client_secret = '999999999'
-auth = ExactTargetRest::Authorization.new(client_id, client_secret)
+auth = ExactTargetRest::Authorization.new(auth_url, client_id, client_secret)
 ```
 
 ### TriggeredSend Activation

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,12 @@
+name: exact-target-rest
+
+up:
+  - ruby: 2.6.5
+  - bundler
+
+commands:
+  test:
+    syntax:
+      argument: file
+      optional: args...
+    run: bundle exec rspec "$@"

--- a/exact_target_rest.gemspec
+++ b/exact_target_rest.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4.0'
-  spec.add_development_dependency 'webmock', '~> 2.1.0'
+  spec.add_development_dependency 'pry', '~> 0.13'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
+  spec.add_development_dependency 'webmock', '~> 3.10.0'
 end

--- a/lib/exact_target_rest.rb
+++ b/lib/exact_target_rest.rb
@@ -3,10 +3,8 @@ require 'faraday_middleware'
 
 module ExactTargetRest
   FARADAY_ADAPTER = :net_http
-  AUTH_URL = 'https://auth.exacttargetapis.com/v1/requestToken'
-  TRIGGERED_SEND_URL = 'https://www.exacttargetapis.com'
+  AUTH_PATH = '/v2/token'
   TRIGGERED_SEND_PATH = '/messaging/v1/messageDefinitionSends/key:%s/send'
-  DATA_EXTENSION_URL = 'https://www.exacttargetapis.com'
   DATA_EXTENSION_PATH = '/hub/v1/dataevents/key:%s/rowset'
 end
 

--- a/lib/exact_target_rest/authorization.rb
+++ b/lib/exact_target_rest/authorization.rb
@@ -4,16 +4,21 @@ module ExactTargetRest
   # You can create "Client ID" and "Client Secret" in ExactTarget
   # App Center (https://appcenter-auth.exacttargetapps.com).
   class Authorization
+    attr_reader :auth_url
     attr_reader :access_token
     attr_reader :expires_in
     attr_reader :expires_at
+    attr_reader :rest_instance_url
 
     # New authorization (it does not trigger REST yet).
     #
+    # @param auth_url [String] Authentication URL
     # @param client_id [String] Client ID
     # @param client_secret [String] Client Secret
-    def initialize(client_id, client_secret)
-      @client_id, @client_secret = client_id, client_secret
+    def initialize(auth_url, client_id, client_secret)
+      @auth_url = auth_url
+      @client_id = client_id
+      @client_secret = client_secret
     end
 
     # Guarantee the block to run authorized.
@@ -31,13 +36,16 @@ module ExactTargetRest
     # Execute authorization, keeps an access token and returns the result
     def authorize!
       resp = endpoint.post do |p|
-        p.body = {clientId: @client_id,
-                  clientSecret: @client_secret}
+        p.url(AUTH_PATH)
+        p.body = {client_id: @client_id,
+                  client_secret: @client_secret,
+                  grant_type: 'client_credentials'}
       end
       if resp.success?
-        @access_token = resp.body['accessToken']
-        @expires_in = resp.body['expiresIn']
+        @access_token = resp.body['access_token']
+        @expires_in = resp.body['expires_in']
         @expires_at = Time.now + @expires_in
+        @rest_instance_url = resp.body['rest_instance_url']
         self
       else
         fail NotAuthorizedError
@@ -52,7 +60,7 @@ module ExactTargetRest
     protected
 
     def endpoint
-      Faraday.new(url: AUTH_URL) do |f|
+      Faraday.new(url: auth_url) do |f|
         f.request :json
         f.response :json, content_type: /\bjson$/
         f.adapter FARADAY_ADAPTER

--- a/lib/exact_target_rest/data_extension.rb
+++ b/lib/exact_target_rest/data_extension.rb
@@ -1,5 +1,7 @@
 module ExactTargetRest
   class DataExtension
+    attr_reader :authorization
+
     # Execute operations over DataExtension
     #
     # @param authorization [Authorization]
@@ -27,6 +29,7 @@ module ExactTargetRest
           p.headers['Authorization'] = "Bearer #{access_token}"
           p.body = @param_formatter.transform(data_extension_rows)
         end
+        raise StandardError.new(resp.body) if resp.status == 400
         raise NotAuthorizedError if resp.status == 401
         resp
       end
@@ -35,7 +38,7 @@ module ExactTargetRest
     protected
 
     def endpoint
-      @endpoint ||= Faraday.new(url: DATA_EXTENSION_URL) do |f|
+      @endpoint ||= Faraday.new(url: authorization.rest_instance_url) do |f|
         f.request :json
         f.response :json, content_type: /\bjson$/
         f.adapter FARADAY_ADAPTER

--- a/lib/exact_target_rest/triggered_send.rb
+++ b/lib/exact_target_rest/triggered_send.rb
@@ -1,5 +1,7 @@
 module ExactTargetRest
   class TriggeredSend
+    attr_reader :authorization
+
     # Execute TriggeredSends to one or several subscribers.
     #
     # @param authorization [Authorization]
@@ -93,7 +95,7 @@ module ExactTargetRest
     protected
 
     def endpoint
-      Faraday.new(url: TRIGGERED_SEND_URL) do |f|
+      Faraday.new(url: authorization.rest_instance_url) do |f|
         f.request :json
         f.response :json, content_type: /\bjson$/
         f.adapter FARADAY_ADAPTER

--- a/spec/lib/exact_target_rest/authorization_spec.rb
+++ b/spec/lib/exact_target_rest/authorization_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper'
 
 describe Authorization do
 
+  let(:auth_url) { "https://auth-url" }
   let(:client_id) { "12345" }
   let(:client_secret) { "Y9axRxR9bcvSW2cc0IwoWeq7" }
   let(:expires_in) { 3600 }
+  let(:rest_instance_url) { "https://instance-url" }
 
   let(:access_token) { "75sf4WWbwfr6HYd5URpC6KBk" }
 
@@ -18,21 +20,21 @@ describe Authorization do
 
   describe '#with_authorization' do
     it "returns a valid authorization" do
-      subject.new(client_id, client_secret).with_authorization do |access_token|
+      subject.new(auth_url, client_id, client_secret).with_authorization do |access_token|
         expect(access_token).to eq access_token
       end
     end
 
     it "returns Unauthorized" do
       expect {
-        subject.new("invalid", client_secret).with_authorization
+        subject.new(auth_url, "invalid", client_secret).with_authorization
       }.to raise_error NotAuthorizedError
     end
   end
 
   describe '#authorize!' do
     it "returns a valid authorization" do
-      auth = subject.new(client_id, client_secret).authorize!
+      auth = subject.new(auth_url, client_id, client_secret).authorize!
 
       expect(auth.access_token).to eq access_token
       expect(auth.expires_in).not_to be_nil
@@ -40,20 +42,20 @@ describe Authorization do
 
     it "returns Unauthorized" do
       expect {
-        subject.new("invalid", client_secret).authorize!
+        subject.new(auth_url, "invalid", client_secret).authorize!
       }.to raise_error NotAuthorizedError
     end
   end
 
   describe '#authorized?' do
     it "returns TRUE when authorization NOT Expired" do
-      auth = subject.new(client_id, client_secret).authorize!
+      auth = subject.new(auth_url, client_id, client_secret).authorize!
 
       expect(auth.authorized?).to be true
     end
 
     it "returns FALSE when authorization Expired" do
-      auth = subject.new(client_id, client_secret).authorize!
+      auth = subject.new(auth_url, client_id, client_secret).authorize!
 
       allow(Time).to receive(:now).and_return(auth.expires_at + 1)
       expect(auth.authorized?).to be false
@@ -62,7 +64,7 @@ describe Authorization do
 
   describe '#to_yaml' do
     it "serializes and deserializes Authorization" do
-      auth = subject.new(client_id, client_secret).authorize!
+      auth = subject.new(auth_url, client_id, client_secret).authorize!
 
       expect(YAML::load(auth.to_yaml)).to be_instance_of(ExactTargetRest::Authorization)
     end
@@ -71,21 +73,21 @@ describe Authorization do
   private
 
   def stub_requests
-    stub_request(:post, ExactTargetRest::AUTH_URL).
+    stub_request(:post, "#{auth_url}#{AUTH_PATH}").
       with(
-        :body => "{\"clientId\":\"#{client_id}\",\"clientSecret\":\"#{client_secret}\"}",
-        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
+        :body => "{\"client_id\":\"#{client_id}\",\"client_secret\":\"#{client_secret}\",\"grant_type\":\"client_credentials\"}",
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.17.3'}
         ).
       to_return(
         headers: {"Content-Type"=> "application/json"},
-        body: %({"accessToken": "#{access_token}", "expiresIn": 3600}),
+        body: %({"access_token": "#{access_token}", "expires_in": 3600, "rest_instance_url": "#{rest_instance_url}"}),
         status: 200
       )
 
-    stub_request(:any, ExactTargetRest::AUTH_URL).
+    stub_request(:any, "#{auth_url}#{AUTH_PATH}").
       with(
-        :body => "{\"clientId\":\"invalid\",\"clientSecret\":\"#{client_secret}\"}",
-        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
+        :body => "{\"client_id\":\"invalid\",\"client_secret\":\"#{client_secret}\",\"grant_type\":\"client_credentials\"}",
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.17.3'}
         ).
       to_return(
         headers: {"Content-Type"=> "application/json"},

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe TriggeredSend do
-
+  let(:auth_url) { "https://auth-url" }
+  let(:rest_instance_url) { "https://instance-url" }
   let(:external_key) { "12345" }
   let(:access_token) { "Y9axRxR9bcvSW2cc0IwoWeq7" }
   let(:expires_in) { 3600 }
@@ -9,6 +10,7 @@ describe TriggeredSend do
   subject do
     authorization = instance_double("ExactTargetRest::Authorization")
     allow(authorization).to receive(:with_authorization).and_yield(access_token)
+    allow(authorization).to receive(:rest_instance_url).and_return(rest_instance_url)
     described_class.new(authorization,external_key)
   end
 
@@ -58,7 +60,7 @@ describe TriggeredSend do
 
   describe '#to_yaml' do
     it "serializes and deserializes TriggeredSend" do
-      authorization = ExactTargetRest::Authorization.new("client_id", "client_secret").authorize!
+      authorization = ExactTargetRest::Authorization.new(auth_url, "client_id", "client_secret").authorize!
 
       ts = ExactTargetRest::TriggeredSend.new(authorization, "external_key").
         with_options(
@@ -73,17 +75,17 @@ describe TriggeredSend do
   private
 
   def stub_requests
-    stub_request(:any, ExactTargetRest::AUTH_URL).
+    stub_request(:any, "#{auth_url}#{AUTH_PATH}").
       to_return(
         headers: {"Content-Type"=> "application/json"},
-        body: %({"accessToken": "75sf4WWbwfr6HYd5URpC6KBk", "expiresIn": 3600}),
+        body: %({"access_token": "75sf4WWbwfr6HYd5URpC6KBk", "expires_in": 3600}),
         status: 200
       )
 
     stub_request(:post, triggered_send_url).
       with(
         :body => "{\"From\":{\"Address\":\"\",\"Name\":\"\"},\"To\":{\"Address\":\"jake@oo.com\",\"SubscriberKey\":\"jake@oo.com\",\"ContactAttributes\":{\"SubscriberAttributes\":{\"City\":\"São Paulo\",\"Zip\":\"04063-040\"}}},\"OPTIONS\":{\"RequestType\":\"ASYNC\"}}",
-        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.17.3'}
       ).
       to_return(
         headers: {"Content-Type"=> "application/json"},
@@ -94,7 +96,7 @@ describe TriggeredSend do
     stub_request(:post, triggered_send_url).
       with(
         :body => "{\"From\":{\"Address\":\"\",\"Name\":\"\"},\"To\":{\"Address\":\"jake@oo.com\",\"SubscriberKey\":\"jake@oo.com\",\"ContactAttributes\":{\"SubscriberAttributes\":{\"City\":\"São Paulo\",\"Profile ID\":\"42\"}}},\"OPTIONS\":{\"RequestType\":\"ASYNC\"}}",
-        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.17.3'}
       ).
       to_return(
         headers: {"Content-Type"=> "application/json"},
@@ -105,7 +107,7 @@ describe TriggeredSend do
     stub_request(:post, triggered_send_url).
       with(
         :body => "{\"From\":{\"Address\":\"\",\"Name\":\"\"},\"To\":{\"Address\":\"jake@oo.com\",\"SubscriberKey\":\"jake@oo.com\",\"ContactAttributes\":{\"SubscriberAttributes\":{}}},\"OPTIONS\":{\"RequestType\":\"ASYNC\"}}",
-        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>"Bearer #{access_token}", 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.17.3'}
         ).
       to_return(
         headers: {"Content-Type"=> "application/json"},
@@ -115,7 +117,7 @@ describe TriggeredSend do
   end
 
   def triggered_send_url
-    "#{TRIGGERED_SEND_URL}#{TRIGGERED_SEND_PATH}" % external_key
+    "#{rest_instance_url}#{TRIGGERED_SEND_PATH}" % external_key
   end
 
   def stub_response(mockId)


### PR DESCRIPTION
We are removing support for legacy authentication and moving to V2

https://developer.salesforce.com/docs/atlas.en-us.mc-app-development.meta/mc-app-development/create-integration-legacy.htm

> As of August 1, 2019, Marketing Cloud has removed the ability to create legacy packages. All new packages are enhanced packages. You can still use legacy authentication and API requests with existing legacy packages.

